### PR TITLE
Refactor parse_var -> std::string_view constructor

### DIFF
--- a/include/argz/argz.hpp
+++ b/include/argz/argz.hpp
@@ -67,18 +67,10 @@ namespace argz
       template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
       template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
       
-      inline std::string_view parse_var(const char* c) {
-         auto start = c;
-         while (*c != '\0') {
-            ++c;
-         }
-         return { start, static_cast<size_t>(c - start) };
-      }
-      
       inline void parse(const char* const c, var& v)
       {
          if (c) {
-            const auto str = parse_var(c);
+            const auto str = std::string_view{ c };
             std::visit(overloaded{
                [&](ref<std::string>& x) { x.get() = str; },
                [&](ref<bool>& x) { x.get() = str == "true" ? true : false; },
@@ -158,11 +150,10 @@ namespace argz
          }
          ++flag;
          
-         std::string_view str;
          if (*flag == '-') {
             ++flag;
          }
-         str = detail::parse_var(flag);
+         auto str = std::string_view{ flag };
          if (str == "h" || str == "help") {
             help(about, opts);
             continue;

--- a/include/argz/argz.hpp
+++ b/include/argz/argz.hpp
@@ -70,7 +70,7 @@ namespace argz
       inline void parse(const char* const c, var& v)
       {
          if (c) {
-            const auto str = std::string_view{ c };
+            const std::string_view str{ c };
             std::visit(overloaded{
                [&](ref<std::string>& x) { x.get() = str; },
                [&](ref<bool>& x) { x.get() = str == "true" ? true : false; },
@@ -153,7 +153,7 @@ namespace argz
          if (*flag == '-') {
             ++flag;
          }
-         auto str = std::string_view{ flag };
+         std::string_view str{ flag };
          if (str == "h" || str == "help") {
             help(about, opts);
             continue;


### PR DESCRIPTION
I realized that `detail::parse_var` is equivalent to [4th constructor of std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view), so this PR is just to simplify the code by removing it and using the constructor instead.

Feel free to reject this you don't like PR without functionality change.