### PR TITLE
Fixed empty default options being printed

### DIFF
--- a/include/argz/argz.hpp
+++ b/include/argz/argz.hpp
@@ -119,7 +119,9 @@ namespace argz
          else {
             std::cout << (ids.id.size() == 1 ? "-" : "--") << ids.id;
          }
-         std::cout << "    " << h << ", default: " << detail::to_string(v) << '\n';
+         
+         std::cout << "    " << h;
+         detail::to_string(v).empty() ? std::cout << '\n' : std::cout << ", default: " << detail::to_string(v) << '\n';
       }
       std::cout << '\n';
    }


### PR DESCRIPTION
Before "default:" would always be printed in the help menu.

E.g. the input option from the readme example would become:
-i, --input    the input file, default: 
instead of:
-i, --input    the input file